### PR TITLE
Replaced /titanium﻿ with /platform﻿ in URLs

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -13,7 +13,7 @@ for further details about ARMv6 support.
 
 ## Getting Started
 
-View the [Using Titanium Modules](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
+View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
 started with using this module in your application.
 
 ## Accessing the Module


### PR DESCRIPTION
Replaced `../titanium﻿..` with `../platform﻿..` in any and all URLs of this yaml file.

https://jira.appcelerator.org/browse/MOD-2124